### PR TITLE
Upgrade scandium to 3.10.0

### DIFF
--- a/components/camel-coap/src/main/java/org/apache/camel/coap/CoAPComponent.java
+++ b/components/camel-coap/src/main/java/org/apache/camel/coap/CoAPComponent.java
@@ -41,10 +41,12 @@ import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.URISupport;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.network.CoapEndpoint;
-import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.config.CertificateAuthenticationMode;
+import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.tcp.netty.TcpServerConnector;
 import org.eclipse.californium.elements.tcp.netty.TlsServerConnector;
 import org.eclipse.californium.scandium.DTLSConnector;
+import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,34 +70,30 @@ public class CoAPComponent extends DefaultComponent implements RestConsumerFacto
         }
         if (server == null) {
             CoapEndpoint.Builder coapBuilder = new CoapEndpoint.Builder();
-            NetworkConfig config = NetworkConfig.createStandardWithoutFile();
+            Configuration config = Configuration.createStandardWithoutFile();
             InetSocketAddress address = new InetSocketAddress(port);
-            coapBuilder.setNetworkConfig(config);
+            coapBuilder.setConfiguration(config);
 
             // Configure TLS and / or TCP
             if (CoAPEndpoint.enableDTLS(endpoint.getUri())) {
                 DTLSConnector connector = endpoint.createDTLSConnector(address, false);
                 coapBuilder.setConnector(connector);
             } else if (CoAPEndpoint.enableTCP(endpoint.getUri())) {
-                int tcpThreads = config.getInt(NetworkConfig.Keys.TCP_WORKER_THREADS);
-                int tcpIdleTimeout = config.getInt(NetworkConfig.Keys.TCP_CONNECTION_IDLE_TIMEOUT);
-
                 TcpServerConnector tcpConnector = null;
                 // TLS + TCP
                 if (endpoint.getUri().getScheme().startsWith("coaps")) {
-                    int tlsHandshakeTimeout = config.getInt(NetworkConfig.Keys.TLS_HANDSHAKE_TIMEOUT);
-
                     SSLContext sslContext = endpoint.getSslContextParameters().createSSLContext(getCamelContext());
-                    TlsServerConnector.ClientAuthMode clientAuthMode = TlsServerConnector.ClientAuthMode.NONE;
                     if (endpoint.isClientAuthenticationRequired()) {
-                        clientAuthMode = TlsServerConnector.ClientAuthMode.NEEDED;
+                        config.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.NEEDED);
                     } else if (endpoint.isClientAuthenticationWanted()) {
-                        clientAuthMode = TlsServerConnector.ClientAuthMode.WANTED;
+                        config.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.WANTED);
+                    } else {
+                        config.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.NONE);
                     }
                     tcpConnector = new TlsServerConnector(
-                            sslContext, clientAuthMode, address, tcpThreads, tlsHandshakeTimeout, tcpIdleTimeout);
+                            sslContext, address, config);
                 } else {
-                    tcpConnector = new TcpServerConnector(address, tcpThreads, tcpIdleTimeout);
+                    tcpConnector = new TcpServerConnector(address, config);
                 }
                 coapBuilder.setConnector(tcpConnector);
             } else {

--- a/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPComponentTLSTestBase.java
+++ b/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPComponentTLSTestBase.java
@@ -41,7 +41,6 @@ import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedPskStore;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedSinglePskStore;
-import org.eclipse.californium.scandium.dtls.x509.NewAdvancedCertificateVerifier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -399,14 +398,15 @@ abstract class CoAPComponentTLSTestBase extends CamelTestSupport {
         PrivateKey privateKey = (PrivateKey) keyStore.getKey("service", "security".toCharArray());
         PublicKey publicKey = keyStore.getCertificate("service").getPublicKey();
 
-        NewAdvancedCertificateVerifier advancedCertificateVerifier = id -> {
-            return true;
-        };
-        NewAdvancedCertificateVerifier failedAdvancedCertificateVerifier = id -> {
-            return false;
-        };
+        //        NewAdvancedCertificateVerifier advancedCertificateVerifier = id -> {
+        //            return true;
+        //        };
+        //        NewAdvancedCertificateVerifier failedAdvancedCertificateVerifier = id -> {
+        //            return false;
+        //        };
         KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
-        AdvancedPskStore advancedPskStore = new AdvancedSinglePskStore("some-identity", keyGenerator.generateKey().getEncoded());
+        AdvancedPskStore advancedPskStore
+                = new AdvancedSinglePskStore("some-identity", keyGenerator.generateKey().getEncoded());
 
         context.getRegistry().bind("serviceSSLContextParameters", serviceSSLContextParameters);
         context.getRegistry().bind("selfSignedServiceSSLContextParameters", selfSignedServiceSSLContextParameters);
@@ -419,8 +419,8 @@ abstract class CoAPComponentTLSTestBase extends CamelTestSupport {
 
         context.getRegistry().bind("privateKey", privateKey);
         context.getRegistry().bind("publicKey", publicKey);
-        context.getRegistry().bind("newAdvancedCertificateVerifier", advancedCertificateVerifier);
-        context.getRegistry().bind("failedNewAdvancedCertificateVerifier", failedAdvancedCertificateVerifier);
+        //        context.getRegistry().bind("newAdvancedCertificateVerifier", advancedCertificateVerifier);
+        //        context.getRegistry().bind("failedNewAdvancedCertificateVerifier", failedAdvancedCertificateVerifier);
         context.getRegistry().bind("advancedPskStore", advancedPskStore);
     }
 

--- a/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPMethodRestrictTest.java
+++ b/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPMethodRestrictTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.coap;
 
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
-import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.config.Configuration;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,7 +28,7 @@ public class CoAPMethodRestrictTest extends CoAPTestSupport {
 
     @Test
     void testDefaultCoAPMethodRestrict() {
-        NetworkConfig.createStandardWithoutFile();
+        Configuration.createStandardWithoutFile();
 
         // All request methods should be valid on this endpoint
         assertCoAPMethodRestrictResponse("/test", CoAPConstants.METHOD_RESTRICT_ALL, "GET: /test");
@@ -36,7 +36,7 @@ public class CoAPMethodRestrictTest extends CoAPTestSupport {
 
     @Test
     void testSpecifiedCoAPMethodRestrict() {
-        NetworkConfig.createStandardWithoutFile();
+        Configuration.createStandardWithoutFile();
 
         // Only GET is valid for /test/a
         assertCoAPMethodRestrictResponse("/test/a", "GET", "GET: /test/a");

--- a/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPRestComponentTCPTLSTest.java
+++ b/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPRestComponentTCPTLSTest.java
@@ -28,7 +28,7 @@ import org.apache.camel.support.jsse.SSLContextParameters;
 import org.apache.camel.support.jsse.TrustManagersParameters;
 import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.network.CoapEndpoint;
-import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.tcp.netty.TcpClientConnector;
 import org.eclipse.californium.elements.tcp.netty.TlsClientConnector;
 
@@ -45,10 +45,7 @@ public class CoAPRestComponentTCPTLSTest extends CoAPRestComponentTestBase {
     @Override
     protected void decorateClient(CoapClient client) throws GeneralSecurityException, IOException {
 
-        NetworkConfig config = NetworkConfig.createStandardWithoutFile();
-        int tcpThreads = config.getInt(NetworkConfig.Keys.TCP_WORKER_THREADS);
-        int tcpConnectTimeout = config.getInt(NetworkConfig.Keys.TCP_CONNECT_TIMEOUT);
-        int tcpIdleTimeout = config.getInt(NetworkConfig.Keys.TCP_CONNECTION_IDLE_TIMEOUT);
+        Configuration config = Configuration.createStandardWithoutFile();
 
         KeyStoreParameters truststoreParameters = new KeyStoreParameters();
         truststoreParameters.setResource("truststore.jks");
@@ -60,7 +57,7 @@ public class CoAPRestComponentTCPTLSTest extends CoAPRestComponentTestBase {
         clientSSLContextParameters.setTrustManagers(clientSSLTrustManagers);
 
         SSLContext sslContext = clientSSLContextParameters.createSSLContext(context);
-        TcpClientConnector tcpConnector = new TlsClientConnector(sslContext, tcpThreads, tcpConnectTimeout, tcpIdleTimeout);
+        TcpClientConnector tcpConnector = new TlsClientConnector(sslContext, config);
 
         CoapEndpoint.Builder tcpBuilder = new CoapEndpoint.Builder();
         tcpBuilder.setConnector(tcpConnector);

--- a/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPRestComponentTCPTest.java
+++ b/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPRestComponentTCPTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.coap;
 import org.apache.camel.model.rest.RestConfigurationDefinition;
 import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.network.CoapEndpoint;
-import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.tcp.netty.TcpClientConnector;
 
 /**
@@ -34,11 +34,8 @@ public class CoAPRestComponentTCPTest extends CoAPRestComponentTestBase {
 
     @Override
     protected void decorateClient(CoapClient client) {
-        NetworkConfig config = NetworkConfig.createStandardWithoutFile();
-        int tcpThreads = config.getInt(NetworkConfig.Keys.TCP_WORKER_THREADS);
-        int tcpConnectTimeout = config.getInt(NetworkConfig.Keys.TCP_CONNECT_TIMEOUT);
-        int tcpIdleTimeout = config.getInt(NetworkConfig.Keys.TCP_CONNECTION_IDLE_TIMEOUT);
-        TcpClientConnector tcpConnector = new TcpClientConnector(tcpThreads, tcpConnectTimeout, tcpIdleTimeout);
+        Configuration config = Configuration.createStandardWithoutFile();
+        TcpClientConnector tcpConnector = new TcpClientConnector(config);
         CoapEndpoint.Builder tcpBuilder = new CoapEndpoint.Builder();
         tcpBuilder.setConnector(tcpConnector);
 

--- a/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPRestComponentTLSTest.java
+++ b/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPRestComponentTLSTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.coap;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
-import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 
 import org.apache.camel.model.rest.RestConfigurationDefinition;
 import org.apache.camel.support.jsse.KeyManagersParameters;
@@ -28,8 +28,12 @@ import org.apache.camel.support.jsse.SSLContextParameters;
 import org.apache.camel.support.jsse.TrustManagersParameters;
 import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.scandium.DTLSConnector;
+import org.eclipse.californium.scandium.config.DtlsConfig;
+import org.eclipse.californium.scandium.config.DtlsConfig.DtlsRole;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.dtls.x509.CertificateConfigurationHelper;
 
 /**
  * Test the CoAP Rest Component with UDP + TLS
@@ -44,8 +48,8 @@ public class CoAPRestComponentTLSTest extends CoAPRestComponentTestBase {
     @Override
     protected void decorateClient(CoapClient client) throws GeneralSecurityException, IOException {
 
-        DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
-        builder.setClientOnly();
+        DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder(Configuration.getStandard());
+        builder.set(DtlsConfig.DTLS_ROLE, DtlsRole.CLIENT_ONLY);
 
         KeyStoreParameters truststoreParameters = new KeyStoreParameters();
         truststoreParameters.setCamelContext(context);
@@ -53,8 +57,11 @@ public class CoAPRestComponentTLSTest extends CoAPRestComponentTestBase {
         truststoreParameters.setPassword("storepass");
 
         KeyStore trustStore = truststoreParameters.createKeyStore();
-        Certificate[] certs = new Certificate[] { trustStore.getCertificate(trustStore.aliases().nextElement()) };
-        builder.setTrustStore(certs);
+        X509Certificate[] certs
+                = new X509Certificate[] { (X509Certificate) trustStore.getCertificate(trustStore.aliases().nextElement()) };
+        CertificateConfigurationHelper certificateConfigurationHelper = new CertificateConfigurationHelper();
+        certificateConfigurationHelper.addConfigurationDefaultsForTrusts(certs);
+        builder.setCertificateHelper(certificateConfigurationHelper);
 
         CoapEndpoint.Builder coapBuilder = new CoapEndpoint.Builder();
         coapBuilder.setConnector(new DTLSConnector(builder.build()));

--- a/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPRestComponentTestBase.java
+++ b/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPRestComponentTestBase.java
@@ -31,7 +31,7 @@ import org.eclipse.californium.core.CoapResponse;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
-import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.config.Configuration;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,7 +44,7 @@ abstract class CoAPRestComponentTestBase extends CamelTestSupport {
 
     @Test
     void testCoAP() throws Exception {
-        NetworkConfig.createStandardWithoutFile();
+        Configuration.createStandardWithoutFile();
         CoapClient client;
         CoapResponse rsp;
 
@@ -71,7 +71,7 @@ abstract class CoAPRestComponentTestBase extends CamelTestSupport {
 
     @Test
     void testCoAPMethodNotAllowedResponse() throws Exception {
-        NetworkConfig.createStandardWithoutFile();
+        Configuration.createStandardWithoutFile();
         CoapClient client = new CoapClient(getProtocol() + "://localhost:" + coapport + "/TestResource/Ducky");
         decorateClient(client);
         client.setTimeout(1000000L);
@@ -81,7 +81,7 @@ abstract class CoAPRestComponentTestBase extends CamelTestSupport {
 
     @Test
     void testCoAPNotFoundResponse() throws Exception {
-        NetworkConfig.createStandardWithoutFile();
+        Configuration.createStandardWithoutFile();
         CoapClient client = new CoapClient(getProtocol() + "://localhost:" + coapport + "/foo/bar/cheese");
         decorateClient(client);
         client.setTimeout(1000000L);

--- a/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPTestSupport.java
+++ b/components/camel-coap/src/test/java/org/apache/camel/coap/CoAPTestSupport.java
@@ -20,7 +20,7 @@ import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.camel.util.FileUtil;
 import org.eclipse.californium.core.CoapClient;
-import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.config.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 
 public class CoAPTestSupport extends CamelTestSupport {
@@ -31,7 +31,7 @@ public class CoAPTestSupport extends CamelTestSupport {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        NetworkConfig.createStandardWithoutFile();
+        Configuration.createStandardWithoutFile();
     }
 
     protected CoapClient createClient(String path) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -79,7 +79,7 @@
         <bytebuddy-version>1.14.11</bytebuddy-version>
         <c3p0-version>0.9.5.5</c3p0-version>
         <caffeine-version>3.1.8</caffeine-version>
-        <californium-version>2.8.0</californium-version>
+        <californium-version>3.10.0</californium-version>
         <californium-scandium-version>3.10.0</californium-scandium-version>
         <camunda-version>7.20.0</camunda-version>
         <camel-k-version>2.1.0</camel-k-version>


### PR DESCRIPTION
- adapt compilation
- comment out one last configuration in tests which wasn't compiling
- several test failures (but progress), several are surely a matter to update the camel route in tests

note: the upgrade of scandium is required otherwise there are errosr at runtime. The versiosn must be aligned between californium scandium and scandium for the 3.x stream

